### PR TITLE
Implement a block decoding system

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.4.7: QmRxw1auJDHHwamUiSNf1wNDUCtq7iSnJsuVu1zG4dUa1w
+0.4.8: QmcmUTvep15wj4UGSqDYERTg1U9yQnNzDUGWggWorLdkmt

--- a/coding.go
+++ b/coding.go
@@ -1,0 +1,40 @@
+package format
+
+import (
+	"fmt"
+
+	blocks "github.com/ipfs/go-block-format"
+)
+
+// DecodeBlock functions decode blocks into nodes.
+type DecodeBlockFunc func(block blocks.Block) (Node, error)
+
+// Map from codec types to decoder functions
+type BlockDecoder map[uint64]DecodeBlockFunc
+
+// A default set of block decoders.
+//
+// You SHOULD populate this map from `init` functions in packages that support
+// decoding various IPLD formats. You MUST NOT modify this map once `main` has
+// been called.
+var DefaultBlockDecoder BlockDecoder = map[uint64]DecodeBlockFunc{}
+
+func (b BlockDecoder) Decode(block blocks.Block) (Node, error) {
+	// Short-circuit by cast if we already have a Node.
+	if node, ok := block.(Node); ok {
+		return node, nil
+	}
+
+	ty := block.Cid().Type()
+	if decoder, ok := b[ty]; ok {
+		return decoder(block)
+	} else {
+		// TODO: get the *long* name for this format
+		return nil, fmt.Errorf("unrecognized object type: %d", ty)
+	}
+}
+
+// Decode the given block using the default block decoder.
+func Decode(block blocks.Block) (Node, error) {
+	return DefaultBlockDecoder.Decode(block)
+}

--- a/format.go
+++ b/format.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 
+	blocks "github.com/ipfs/go-block-format"
+
 	cid "github.com/ipfs/go-cid"
 )
 
@@ -18,13 +20,12 @@ type Resolver interface {
 }
 
 type Node interface {
+	blocks.Block
 	Resolver
 
 	// ResolveLink is a helper function that calls resolve and asserts the
 	// output is a link
 	ResolveLink(path []string) (*Link, []string, error)
-
-	Cid() *cid.Cid
 
 	// Copy returns a deep copy of this node
 	Copy() Node
@@ -37,12 +38,6 @@ type Node interface {
 
 	// Size returns the size in bytes of the serialized object
 	Size() (uint64, error)
-
-	// RawData marshals the node and returns the marshaled bytes
-	RawData() []byte
-
-	String() string
-	Loggable() map[string]interface{}
 }
 
 type NodeGetter interface {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,12 @@
       "hash": "QmZe3S3sXMWar3oPmrd8jHV8NoAWfPfLGFD8PsK3YrYpqv",
       "name": "go-cid",
       "version": "0.7.13"
+    },
+    {
+      "author": "stebalien",
+      "hash": "QmeK8xFAXx4GBpZG6mizck1XAunVtxP8Tmvir5FMwp5MYb",
+      "name": "go-block-format",
+      "version": "0.1.0"
     }
   ],
   "gxVersion": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
   "license": "",
   "name": "go-ipld-format",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.4.7"
+  "version": "0.4.8"
 }
 


### PR DESCRIPTION
This way IPLD consumers can decode any supported IPLD format using a single decoder function (assuming the decoding library properly registers its decoder function).