### PR TITLE
rework block decoding framework

### DIFF
--- a/coding_test.go
+++ b/coding_test.go
@@ -10,13 +10,13 @@ import (
 )
 
 func init() {
-	DefaultBlockDecoder[cid.Raw] = func(b blocks.Block) (Node, error) {
+	Register(cid.Raw, func(b blocks.Block) (Node, error) {
 		node := &EmptyNode{}
 		if b.RawData() != nil || !b.Cid().Equals(node.Cid()) {
 			return nil, errors.New("can only decode empty blocks")
 		}
 		return node, nil
-	}
+	})
 }
 
 func TestDecode(t *testing.T) {


### PR DESCRIPTION
1. Use an interface instead of a map so that we can define fancier block
   decoders.
2. Make DefaultBlockDecoder thread safe.