### PR TITLE
gx: update go-cid, go-multibase, base32

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-0.5.0: QmYNyRZJBUYPNrLszFmrBrPJbsBh2vMsefz5gnDpB5M1P6
+0.5.1: QmPN7cwmpcc4DWXb4KTB9dNAJgjuPY69h3npsMfhRrQL9c

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmTprEaAA2A9bst5XH7exuyi5KzNMK3SEDNN8rBDnKWcUS",
+      "hash": "QmNp85zy9RLrQ5oQD4hPyS39ezrrXpcaa7R4Y9kxdWQLLQ",
       "name": "go-cid",
-      "version": "0.7.17"
+      "version": "0.7.18"
     },
     {
       "author": "stebalien",
-      "hash": "QmVA4mafxbfH5aEvNz8fyoxC6J1xhAtw88B4GerPznSZBg",
+      "hash": "QmSn9Td7xgxm9EV7iEjTckpUWmWApggzPxu7eFGWkkpwin",
       "name": "go-block-format",
-      "version": "0.1.3"
+      "version": "0.1.4"
     },
     {
       "author": "multiformats",
@@ -31,6 +31,6 @@
   "license": "",
   "name": "go-ipld-format",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "0.5.0"
+  "version": "0.5.1"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-testutil/pull/12
- https://github.com/libp2p/go-libp2p-conn/pull/15
- https://github.com/libp2p/go-libp2p-connmgr/pull/5
- https://github.com/libp2p/go-libp2p-host/pull/8
- https://github.com/libp2p/go-libp2p-swarm/pull/32
- https://github.com/libp2p/go-libp2p-netutil/pull/11
- https://github.com/libp2p/go-libp2p-blankhost/pull/5
- https://github.com/libp2p/go-libp2p-circuit/pull/14
- https://github.com/libp2p/go-libp2p/pull/221
- https://github.com/libp2p/go-libp2p-kbucket/pull/13
- https://github.com/libp2p/go-libp2p-routing/pull/17
- https://github.com/libp2p/go-libp2p-kad-dht/pull/85
- https://github.com/libp2p/go-floodsub/pull/33
- https://github.com/ipfs/go-block-format/pull/8


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace