### PR TITLE
RFC: Make ErrNotFound a struct and include IsNotFound helper

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -24,7 +24,7 @@ func (d *testDag) Get(ctx context.Context, cid *cid.Cid) (Node, error) {
 	if n, ok := d.nodes[cid.KeyString()]; ok {
 		return n, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrNotFound{cid}
 }
 
 func (d *testDag) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *NodeOption {
@@ -35,7 +35,7 @@ func (d *testDag) GetMany(ctx context.Context, cids []*cid.Cid) <-chan *NodeOpti
 		if n, ok := d.nodes[c.KeyString()]; ok {
 			out <- &NodeOption{Node: n}
 		} else {
-			out <- &NodeOption{Err: ErrNotFound}
+			out <- &NodeOption{Err: ErrNotFound{c}}
 		}
 	}
 	close(out)

--- a/daghelpers.go
+++ b/daghelpers.go
@@ -61,7 +61,7 @@ func GetNodes(ctx context.Context, ds NodeGetter, keys []*cid.Cid) []*NodePromis
 			case opt, ok := <-nodechan:
 				if !ok {
 					for _, p := range promises {
-						p.Fail(ErrNotFound)
+						p.Fail(ErrNotFound{})
 					}
 					return
 				}

--- a/errnotfound.go
+++ b/errnotfound.go
@@ -1,0 +1,26 @@
+package format
+
+import (
+	"fmt"
+
+	cid "github.com/ipfs/go-cid"
+	errs "github.com/pkg/errors"
+)
+
+// ErrNotFound indicates that a CID was not found
+type ErrNotFound struct {
+	Cid *cid.Cid
+}
+
+func (e ErrNotFound) Error() string {
+	if e.Cid == nil {
+		return fmt.Sprintf("CID not found")
+	}
+	return fmt.Sprintf("CID not found: %s", e.Cid)
+}
+
+// IsNotFound returns true if the cause of the error is ErrNotFound
+func IsNotFound(e error) bool {
+	_, ok := errs.Cause(e).(ErrNotFound)
+	return ok
+}

--- a/errnotfound_test.go
+++ b/errnotfound_test.go
@@ -1,0 +1,23 @@
+package format
+
+import (
+	"fmt"
+	"testing"
+
+	errs "github.com/pkg/errors"
+)
+
+func TestIsNotFound(t *testing.T) {
+	err1 := ErrNotFound{}
+	if !IsNotFound(err1) {
+		t.Errorf("IsNotFound not true when it should be")
+	}
+	err2 := errs.Wrap(err1, "wrapped")
+	if !IsNotFound(err2) {
+		t.Errorf("IsNotFound not true on wrapped error when it should be")
+	}
+	err3 := fmt.Errorf("CID not found")
+	if IsNotFound(err3) {
+		t.Errorf("IsNotFound true when it should not be")
+	}
+}

--- a/merkledag.go
+++ b/merkledag.go
@@ -2,12 +2,9 @@ package format
 
 import (
 	"context"
-	"fmt"
 
 	cid "github.com/ipfs/go-cid"
 )
-
-var ErrNotFound = fmt.Errorf("merkledag: not found")
 
 // Either a node or an error.
 type NodeOption struct {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "hash": "QmZyZDi491cCNTLfAhwcaDii2Kg4pwKRkhqQzURGDvY6ua",
       "name": "go-multihash",
       "version": "1.0.7"
+    },
+    {
+      "author": "whyrusleeping",
+      "hash": "QmVmDhyTTUcQXFD1rRQ64fGLMSAoaQvNH3hwuaCFAPq2hy",
+      "name": "errors",
+      "version": "0.0.1"
     }
   ],
   "gxVersion": "0.10.0",


### PR DESCRIPTION
The IsNotFound helper allows the error to be wrapped by using pkg/errors.Cause(...).

Next Steps:
 1. Have the blockstore use this error instead of its own internal error when a Cid is not found.  This will simplfy the merkeldag code.
 2. Fix go-ipfs code which includes (1) the simplification of the merkeldag code and (2) using IsNotFound instead of testing for the error directly.

**DO NOT MERGE** until steps 1 and 2 are done in case of problems.

Closes https://github.com/ipfs/go-ipfs/pull/4468
Also See: https://github.com/ipfs/go-ipfs/pull/4099