### PR TITLE
bump go-cid version to 0.7.22 and go-block-format to 0.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
   "gxDependencies": [
     {
       "author": "whyrusleeping",
-      "hash": "QmapdYm1b22Frv3k17fqrBYTFRxwiaVJkB299Mfn33edeB",
+      "hash": "QmYVNvtQkeZ6AKSwDrjQTs432QtL6umrrK41EBq3cu7iSP",
       "name": "go-cid",
-      "version": "0.7.21"
+      "version": "0.7.22"
     },
     {
       "author": "stebalien",

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     },
     {
       "author": "stebalien",
-      "hash": "QmTRCUvZLiir12Qr6MV3HKfKMHX8Nf1Vddn6t2g5nsQSb9",
+      "hash": "QmVzK524a2VWLqyvtBeiHKsUAWYgeAk4DBeZoY7vpNPNRx",
       "name": "go-block-format",
-      "version": "0.1.7"
+      "version": "0.1.8"
     },
     {
       "author": "multiformats",


### PR DESCRIPTION
Propagates a bugfix in service of https://github.com/filecoin-project/go-filecoin/issues/626