### PR TITLE
Improve "merkledag: not found" error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
 language: go
 
 go:
-  - 1.12.x
+  - 1.14.x
 
 env:
   global:

--- a/batch_test.go
+++ b/batch_test.go
@@ -26,7 +26,7 @@ func (d *testDag) Get(ctx context.Context, cid cid.Cid) (Node, error) {
 	if n, ok := d.nodes[cid.KeyString()]; ok {
 		return n, nil
 	}
-	return nil, ErrNotFoundCid{cid}
+	return nil, ErrNotFound{cid}
 }
 
 func (d *testDag) GetMany(ctx context.Context, cids []cid.Cid) <-chan *NodeOption {
@@ -37,7 +37,7 @@ func (d *testDag) GetMany(ctx context.Context, cids []cid.Cid) <-chan *NodeOptio
 		if n, ok := d.nodes[c.KeyString()]; ok {
 			out <- &NodeOption{Node: n}
 		} else {
-			out <- &NodeOption{Err: ErrNotFoundCid{c}}
+			out <- &NodeOption{Err: ErrNotFound{c}}
 		}
 	}
 	close(out)
@@ -157,11 +157,11 @@ func TestErrorTypes(t *testing.T) {
 
 	err2 := fmt.Errorf("could not read: %w", err)
 
-	if !errors.Is(err, ErrNotFound) {
+	if !errors.Is(err, ErrNotFound{}) {
 		t.Fatal("should be an ErrNotFound")
 	}
 
-	if !errors.Is(err2, ErrNotFound) {
+	if !errors.Is(err2, ErrNotFound{}) {
 		t.Fatal("should be an ErrNotFound")
 	}
 }

--- a/batch_test.go
+++ b/batch_test.go
@@ -2,6 +2,8 @@ package format
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"sync"
 	"testing"
 
@@ -24,7 +26,7 @@ func (d *testDag) Get(ctx context.Context, cid cid.Cid) (Node, error) {
 	if n, ok := d.nodes[cid.KeyString()]; ok {
 		return n, nil
 	}
-	return nil, ErrNotFound
+	return nil, ErrNotFoundCid{cid}
 }
 
 func (d *testDag) GetMany(ctx context.Context, cids []cid.Cid) <-chan *NodeOption {
@@ -35,7 +37,7 @@ func (d *testDag) GetMany(ctx context.Context, cids []cid.Cid) <-chan *NodeOptio
 		if n, ok := d.nodes[c.KeyString()]; ok {
 			out <- &NodeOption{Node: n}
 		} else {
-			out <- &NodeOption{Err: ErrNotFound}
+			out <- &NodeOption{Err: ErrNotFoundCid{c}}
 		}
 	}
 	close(out)
@@ -142,5 +144,24 @@ func TestBatchOptions(t *testing.T) {
 	}
 	if b.opts.maxNodes != wantMaxNodes {
 		t.Fatalf("maxNodes incorrect, want: %d, got: %d", wantMaxNodes, b.opts.maxNodes)
+	}
+}
+
+func TestErrorTypes(t *testing.T) {
+	d := newTestDag()
+	notFoundNode := &EmptyNode{}
+	_, err := d.Get(context.Background(), notFoundNode.Cid())
+	if err == nil {
+		t.Fatal("should throw NotFound error")
+	}
+
+	err2 := fmt.Errorf("could not read: %w", err)
+
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatal("should be an ErrNotFound")
+	}
+
+	if !errors.Is(err2, ErrNotFound) {
+		t.Fatal("should be an ErrNotFound")
 	}
 }

--- a/daghelpers.go
+++ b/daghelpers.go
@@ -61,7 +61,7 @@ func GetNodes(ctx context.Context, ds NodeGetter, keys []cid.Cid) []*NodePromise
 			case opt, ok := <-nodechan:
 				if !ok {
 					for _, p := range promises {
-						p.Fail(ErrNotFound)
+						p.Fail(ErrNotFound{})
 					}
 					return
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/ipfs/go-ipld-format
 
+go 1.14
+
 require (
 	github.com/ipfs/go-block-format v0.0.2
 	github.com/ipfs/go-cid v0.0.2

--- a/merkledag.go
+++ b/merkledag.go
@@ -10,33 +10,35 @@ import (
 // ErrNotFound is used to signal when a Node could not be found. The specific
 // meaning will depend on the DAGService implementation, which may be trying
 // to read nodes locally but also, trying to find them remotely.
-var ErrNotFound = ErrNotFoundCid{}
-
-// ErrNotFoundCid can be use to provide specific CID information in a NotFound
-// error.
-type ErrNotFoundCid struct {
-	c cid.Cid
+//
+// The Cid field can be filled in to provide additional context.
+type ErrNotFound struct {
+	Cid cid.Cid
 }
 
 // Error implements the error interface and returns a human-readable
 // message for this error.
-func (e ErrNotFoundCid) Error() string {
-	if e.c == cid.Undef {
+func (e ErrNotFound) Error() string {
+	if e.Cid == cid.Undef {
 		return "ipld: node not found"
 	}
 
-	return fmt.Sprintf("ipld: %s not found", e.c)
+	return fmt.Sprintf("ipld: %s not found", e.Cid)
 }
 
-// Is allows to check whether any error is of this ErrNotFoundCid type.
+// Is allows to check whether any error is of this ErrNotFound type.
 // Do not use this directly, but rather errors.Is(yourError, ErrNotFound).
-func (e ErrNotFoundCid) Is(err error) bool {
+func (e ErrNotFound) Is(err error) bool {
 	switch err.(type) {
-	case ErrNotFoundCid:
+	case ErrNotFound:
 		return true
 	default:
 		return false
 	}
+}
+
+func (e ErrNotFound) NotFound() bool {
+	return true
 }
 
 // Either a node or an error.

--- a/merkledag.go
+++ b/merkledag.go
@@ -2,6 +2,7 @@ package format
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	cid "github.com/ipfs/go-cid"
@@ -39,6 +40,12 @@ func (e ErrNotFound) Is(err error) bool {
 
 func (e ErrNotFound) NotFound() bool {
 	return true
+}
+
+// IsNotFound returns if the given error is or wraps an ErrNotFound
+// (equivalent to errors.Is(err, ErrNotFound{}))
+func IsNotFound(err error) bool {
+	return errors.Is(err, ErrNotFound{})
 }
 
 // Either a node or an error.

--- a/merkledag.go
+++ b/merkledag.go
@@ -7,7 +7,37 @@ import (
 	cid "github.com/ipfs/go-cid"
 )
 
-var ErrNotFound = fmt.Errorf("merkledag: not found")
+// ErrNotFound is used to signal when a Node could not be found. The specific
+// meaning will depend on the DAGService implementation, which may be trying
+// to read nodes locally but also, trying to find them remotely.
+var ErrNotFound = ErrNotFoundCid{}
+
+// ErrNotFoundCid can be use to provide specific CID information in a NotFound
+// error.
+type ErrNotFoundCid struct {
+	c cid.Cid
+}
+
+// Error implements the error interface and returns a human-readable
+// message for this error.
+func (e ErrNotFoundCid) Error() string {
+	if e.c == cid.Undef {
+		return "ipld: node not found"
+	}
+
+	return fmt.Sprintf("ipld: %s not found", e.c)
+}
+
+// Is allows to check whether any error is of this ErrNotFoundCid type.
+// Do not use this directly, but rather errors.Is(yourError, ErrNotFound).
+func (e ErrNotFoundCid) Is(err error) bool {
+	switch err.(type) {
+	case ErrNotFoundCid:
+		return true
+	default:
+		return false
+	}
+}
 
 // Either a node or an error.
 type NodeOption struct {


### PR DESCRIPTION
Based on #33, taking advantage of the rather new Is() methods from the errors
package to check for equality.