### PR TITLE
Revert ErrNotFound improvements

### DIFF
--- a/batch_test.go
+++ b/batch_test.go
@@ -2,8 +2,6 @@ package format
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sync"
 	"testing"
 
@@ -26,7 +24,7 @@ func (d *testDag) Get(ctx context.Context, cid cid.Cid) (Node, error) {
 	if n, ok := d.nodes[cid.KeyString()]; ok {
 		return n, nil
 	}
-	return nil, ErrNotFound{cid}
+	return nil, ErrNotFound
 }
 
 func (d *testDag) GetMany(ctx context.Context, cids []cid.Cid) <-chan *NodeOption {
@@ -37,7 +35,7 @@ func (d *testDag) GetMany(ctx context.Context, cids []cid.Cid) <-chan *NodeOptio
 		if n, ok := d.nodes[c.KeyString()]; ok {
 			out <- &NodeOption{Node: n}
 		} else {
-			out <- &NodeOption{Err: ErrNotFound{c}}
+			out <- &NodeOption{Err: ErrNotFound}
 		}
 	}
 	close(out)
@@ -144,24 +142,5 @@ func TestBatchOptions(t *testing.T) {
 	}
 	if b.opts.maxNodes != wantMaxNodes/parallelCommits {
 		t.Fatalf("maxNodes incorrect, want: %d, got: %d", wantMaxNodes, b.opts.maxNodes)
-	}
-}
-
-func TestErrorTypes(t *testing.T) {
-	d := newTestDag()
-	notFoundNode := &EmptyNode{}
-	_, err := d.Get(context.Background(), notFoundNode.Cid())
-	if err == nil {
-		t.Fatal("should throw NotFound error")
-	}
-
-	err2 := fmt.Errorf("could not read: %w", err)
-
-	if !errors.Is(err, ErrNotFound{}) {
-		t.Fatal("should be an ErrNotFound")
-	}
-
-	if !errors.Is(err2, ErrNotFound{}) {
-		t.Fatal("should be an ErrNotFound")
 	}
 }

--- a/daghelpers.go
+++ b/daghelpers.go
@@ -61,7 +61,7 @@ func GetNodes(ctx context.Context, ds NodeGetter, keys []cid.Cid) []*NodePromise
 			case opt, ok := <-nodechan:
 				if !ok {
 					for _, p := range promises {
-						p.Fail(ErrNotFound{})
+						p.Fail(ErrNotFound)
 					}
 					return
 				}

--- a/merkledag.go
+++ b/merkledag.go
@@ -2,51 +2,12 @@ package format
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	cid "github.com/ipfs/go-cid"
 )
 
-// ErrNotFound is used to signal when a Node could not be found. The specific
-// meaning will depend on the DAGService implementation, which may be trying
-// to read nodes locally but also, trying to find them remotely.
-//
-// The Cid field can be filled in to provide additional context.
-type ErrNotFound struct {
-	Cid cid.Cid
-}
-
-// Error implements the error interface and returns a human-readable
-// message for this error.
-func (e ErrNotFound) Error() string {
-	if e.Cid == cid.Undef {
-		return "ipld: node not found"
-	}
-
-	return fmt.Sprintf("ipld: %s not found", e.Cid)
-}
-
-// Is allows to check whether any error is of this ErrNotFound type.
-// Do not use this directly, but rather errors.Is(yourError, ErrNotFound).
-func (e ErrNotFound) Is(err error) bool {
-	switch err.(type) {
-	case ErrNotFound:
-		return true
-	default:
-		return false
-	}
-}
-
-func (e ErrNotFound) NotFound() bool {
-	return true
-}
-
-// IsNotFound returns if the given error is or wraps an ErrNotFound
-// (equivalent to errors.Is(err, ErrNotFound{}))
-func IsNotFound(err error) bool {
-	return errors.Is(err, ErrNotFound{})
-}
+var ErrNotFound = fmt.Errorf("merkledag: not found")
 
 // Either a node or an error.
 type NodeOption struct {


### PR DESCRIPTION
Squashed for easier, future revert of the revert.

---
Revert "Add IsErrNotFound() method"

This reverts commit 3d8b689431f011b1b8605a2f7a156a4991bb7f2d.

Revert "ErrNotFound: Make struct. Expose Cid field. Implement NotFound()"

This reverts commit 0ae16c843956d23010ec10dba15cb1dbb4109036.

Revert "Improve "merkledag: not found" error"

This reverts commit d651505886b65770ce11e7e46d79322f46ec6079.