### PR TITLE
Allowing custom NavigableNode implementations

### DIFF
--- a/navipld.go
+++ b/navipld.go
@@ -134,7 +134,7 @@ func (nn *NavigableIPLDNode) ChildTotal() uint {
 // function.
 // TODO: Check for errors to avoid a panic?
 func ExtractIPLDNode(node NavigableNode) Node {
-	return node.(*NavigableIPLDNode).GetIPLDNode()
+	return node.GetIPLDNode()
 }
 
 // TODO: `Cleanup` is not supported at the moment in the `Walker`.

--- a/walker.go
+++ b/walker.go
@@ -116,6 +116,9 @@ type NavigableNode interface {
 	// ChildTotal returns the number of children of the `ActiveNode`.
 	ChildTotal() uint
 
+	// GetIPLDNode returns actual IPLD Node
+	GetIPLDNode() Node
+
 	// TODO: Evaluate providing the `Cleanup` and `Reset` methods.
 
 	// Cleanup is an optional method that is called by the `Walker` when


### PR DESCRIPTION
Currently, implementing custom NavigableNode has no point due to `ExtractIPLDNode`. It forces users(DAGReader) to stick with NavigableIPLDNode implementation through type assertion to get an actual Node. The PR is intended to fix this without any breaking changes by adding the 'GetIPLDNode' method to the interface.

My use case also requires DAGReader usage with custom NavigableNode, but it's constructor [strict to single implementation](https://github.com/ipfs/go-unixfs/blob/master/io/dagreader.go#L97). I propose to add options for DagReader to resolve the case. I will raise a PR there in case this one is accepted. 

/cc @Stebalien 