### PR TITLE
fix: make Undef ErrNotFound string consistent with Def version

### DIFF
--- a/merkledag.go
+++ b/merkledag.go
@@ -21,7 +21,7 @@ type ErrNotFound struct {
 // message for this error.
 func (e ErrNotFound) Error() string {
 	if e.Cid == cid.Undef {
-		return "ipld: node not found"
+		return "node not found"
 	}
 
 	return fmt.Sprintf("%s not found", e.Cid)

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "version": "v0.3.0"
+  "version": "v0.3.1"
 }


### PR DESCRIPTION
389f7618ee130621bbcd68b310f694da2f93b78a updated the fmt.Sprintf version used when the CID is known, but not the version for default CIDs.

This commit has been extracted from #70 since #70 has been dropped.