### PR TITLE
feat: remove block decoding global registry

### DIFF
--- a/coding.go
+++ b/coding.go
@@ -2,44 +2,53 @@ package format
 
 import (
 	"fmt"
-	"sync"
-
 	blocks "github.com/ipfs/go-block-format"
 )
 
 // DecodeBlockFunc functions decode blocks into nodes.
 type DecodeBlockFunc func(block blocks.Block) (Node, error)
 
-type BlockDecoder interface {
-	Register(codec uint64, decoder DecodeBlockFunc)
-	Decode(blocks.Block) (Node, error)
-}
-type safeBlockDecoder struct {
-	// Can be replaced with an RCU if necessary.
-	lock     sync.RWMutex
+// Registry is a structure for storing mappings of multicodec IPLD codec numbers to DecodeBlockFunc functions.
+//
+// Registry includes no mutexing. If using Registry in a concurrent context, you must handle synchronization yourself.
+// (Typically, it is recommended to do initialization earlier in a program, before fanning out goroutines;
+// this avoids the need for mutexing overhead.)
+//
+// Multicodec indicator numbers are specified in
+// https://github.com/multiformats/multicodec/blob/master/table.csv .
+// You should not use indicator numbers which are not specified in that table
+// (however, there is nothing in this implementation that will attempt to stop you, either).
+type Registry struct {
 	decoders map[uint64]DecodeBlockFunc
+}
+
+func (r *Registry) ensureInit() {
+	if r.decoders != nil {
+		return
+	}
+	r.decoders = make(map[uint64]DecodeBlockFunc)
 }
 
 // Register registers decoder for all blocks with the passed codec.
 //
 // This will silently replace any existing registered block decoders.
-func (d *safeBlockDecoder) Register(codec uint64, decoder DecodeBlockFunc) {
-	d.lock.Lock()
-	defer d.lock.Unlock()
-	d.decoders[codec] = decoder
+func (r *Registry) Register(codec uint64, decoder DecodeBlockFunc) {
+	r.ensureInit()
+	if decoder == nil {
+		panic("not sensible to attempt to register a nil function")
+	}
+	r.decoders[codec] = decoder
 }
 
-func (d *safeBlockDecoder) Decode(block blocks.Block) (Node, error) {
+func (r *Registry) Decode(block blocks.Block) (Node, error) {
 	// Short-circuit by cast if we already have a Node.
 	if node, ok := block.(Node); ok {
 		return node, nil
 	}
 
 	ty := block.Cid().Type()
-
-	d.lock.RLock()
-	decoder, ok := d.decoders[ty]
-	d.lock.RUnlock()
+	r.ensureInit()
+	decoder, ok := r.decoders[ty]
 
 	if ok {
 		return decoder(block)
@@ -49,14 +58,13 @@ func (d *safeBlockDecoder) Decode(block blocks.Block) (Node, error) {
 	}
 }
 
-var DefaultBlockDecoder BlockDecoder = &safeBlockDecoder{decoders: make(map[uint64]DecodeBlockFunc)}
+// Decode decodes the given block using passed DecodeBlockFunc.
+// Note: this is just a helper function, consider using the DecodeBlockFunc itself rather than this helper
+func Decode(block blocks.Block, decoder DecodeBlockFunc) (Node, error) {
+	// Short-circuit by cast if we already have a Node.
+	if node, ok := block.(Node); ok {
+		return node, nil
+	}
 
-// Decode decodes the given block using the default BlockDecoder.
-func Decode(block blocks.Block) (Node, error) {
-	return DefaultBlockDecoder.Decode(block)
-}
-
-// Register registers block decoders with the default BlockDecoder.
-func Register(codec uint64, decoder DecodeBlockFunc) {
-	DefaultBlockDecoder.Register(codec, decoder)
+	return decoder(block)
 }

--- a/coding_test.go
+++ b/coding_test.go
@@ -9,17 +9,15 @@ import (
 	mh "github.com/multiformats/go-multihash"
 )
 
-func init() {
-	Register(cid.Raw, func(b blocks.Block) (Node, error) {
+func TestDecode(t *testing.T) {
+	decoder := func(b blocks.Block) (Node, error) {
 		node := &EmptyNode{}
 		if b.RawData() != nil || !b.Cid().Equals(node.Cid()) {
 			return nil, errors.New("can only decode empty blocks")
 		}
 		return node, nil
-	})
-}
+	}
 
-func TestDecode(t *testing.T) {
 	id, err := cid.Prefix{
 		Version:  1,
 		Codec:    cid.Raw,
@@ -35,10 +33,56 @@ func TestDecode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create empty block: %s", err)
 	}
-	node, err := Decode(block)
+	node, err := Decode(block, decoder)
 	if err != nil {
 		t.Fatalf("failed to decode empty node: %s", err)
 	}
+	if !node.Cid().Equals(id) {
+		t.Fatalf("empty node doesn't have the right cid")
+	}
+
+	if _, ok := node.(*EmptyNode); !ok {
+		t.Fatalf("empty node doesn't have the right type")
+	}
+
+}
+
+func TestRegistryDecode(t *testing.T) {
+	decoder := func(b blocks.Block) (Node, error) {
+		node := &EmptyNode{}
+		if b.RawData() != nil || !b.Cid().Equals(node.Cid()) {
+			return nil, errors.New("can only decode empty blocks")
+		}
+		return node, nil
+	}
+
+	id, err := cid.Prefix{
+		Version:  1,
+		Codec:    cid.Raw,
+		MhType:   mh.ID,
+		MhLength: 0,
+	}.Sum(nil)
+
+	if err != nil {
+		t.Fatalf("failed to create cid: %s", err)
+	}
+
+	block, err := blocks.NewBlockWithCid(nil, id)
+	if err != nil {
+		t.Fatalf("failed to create empty block: %s", err)
+	}
+
+	reg := Registry{}
+	_, err = reg.Decode(block)
+	if err == nil || err.Error() != "unrecognized object type: 85" {
+		t.Fatalf("expected error, got %v", err)
+	}
+	reg.Register(cid.Raw, decoder)
+	node, err := reg.Decode(block)
+	if err != nil {
+		t.Fatalf("failed to decode empty node: %s", err)
+	}
+
 	if !node.Cid().Equals(id) {
 		t.Fatalf("empty node doesn't have the right cid")
 	}


### PR DESCRIPTION
The global registry serves as a footgun for application developers given the subtle way (module initialization ordering) that the registry tends to be used. Historically this hasn't been so much of a problem because there's never been more than one implementation of a given codec that conforms to the go-ipld-format interfaces.

However, that's no longer the case due to their being two forks of the go-ipld-format version of the dag-pb codec ([go-merkledag](https://github.com/ipfs/go-merkledag) maintained by @rvagg and [boxo](https://github.com/ipfs/boxo)'s [fork](https://github.com/ipfs/boxo/tree/main/ipld/merkledag/pb) maintained by @ipfs/kubo-maintainers.

Related to https://github.com/ipfs/boxo/issues/291 and https://github.com/ipfs/go-ipld-legacy/pull/12

From what I can tell via some scanning on grep.app for [ipld.Decode](https://grep.app/search?q=ipld.Decode), and [format.Decode](format.Decode&words=true&filter[lang][0]=Go) as well as GitHub search the blast radius of this change appears fairly minimal and will help as either more codec implementations emerge or get consolidated.

Side note: this would've been a problem with https://github.com/ipld/go-codec-dagpb as well if someone had written a wrapper to make it compatible with go-ipld-format. However, instead it lives in a [different global registry](https://github.com/ipld/go-ipld-prime/blob/b625f253fa5048f09c40a5240580849822cf601c/multicodec/defaultRegistry.go). The go-ipld-prime default registry is similarly at risk of being a problem, although at least users of the global registry are warned about its risks in the comments.

cc @willscott @rvagg @Jorropo